### PR TITLE
:recycle: Normalize Decimal Separator Based on Current Culture

### DIFF
--- a/EXL.Tests/EXL.Tests.csproj
+++ b/EXL.Tests/EXL.Tests.csproj
@@ -15,10 +15,6 @@
     <PackageReference Include="NUnit" Version="3.14.0" />
     <PackageReference Include="NUnit.Analyzers" Version="3.9.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/EXL.Tests/Functions/Mathematical/AcosFunctionTests.cs
+++ b/EXL.Tests/Functions/Mathematical/AcosFunctionTests.cs
@@ -1,48 +1,48 @@
-﻿using EXL.Functions.Mathematical;
-using NUnit.Framework;
+using EXL.Functions.Mathematical;
 
 namespace EXL.Tests.Functions.Mathematical
 {
     [TestFixture]
     internal class AcosFunctionTests
     {
-        private AcosFunction _acosFunction;
+        private AcosFunction acosFunction;
+        internal static readonly object[] args = [];
 
         [SetUp]
         public void SetUp()
         {
-            _acosFunction = new AcosFunction();
+            acosFunction = new AcosFunction();
         }
 
         [Test]
         public void Execute_WithValidNumber_ReturnsAcosValue()
         {
-            var result = _acosFunction.Execute(new object[] { 0.5 });
+            var result = acosFunction.Execute([0.5]);
             Assert.That(result, Is.EqualTo(Math.Acos(0.5)));
         }
 
         [Test]
         public void Execute_WithNumberOutOfRange_ThrowsInvalidOperationException()
         {
-            Assert.Throws<InvalidCastException>(() => _acosFunction.Execute(new object[] { 2 }));
+            Assert.Throws<InvalidOperationException>(() => acosFunction.Execute([2]));
         }
 
         [Test]
         public void Execute_WithInvalidType_ThrowsInvalidOperationException()
         {
-            Assert.Throws<InvalidCastException>(() => _acosFunction.Execute(new object[] { "invalid" }));
+            Assert.Throws<InvalidOperationException>(() => acosFunction.Execute(["invalid"]));
         }
 
         [Test]
         public void Execute_WithMultipleArguments_ThrowsInvalidOperationException()
         {
-            Assert.Throws<InvalidOperationException>(() => _acosFunction.Execute(new object[] { 0.5, 0.5 }));
+            Assert.Throws<InvalidOperationException>(() => acosFunction.Execute([0.5, 0.5]));
         }
 
         [Test]
         public void Execute_WithEmptyArguments_ThrowsInvalidOperationException()
         {
-            Assert.Throws<InvalidOperationException>(() => _acosFunction.Execute(new object[] { }));
+            Assert.Throws<InvalidOperationException>(() => acosFunction.Execute(args));
         }
     }
 }

--- a/EXL.Tests/Functions/Mathematical/AcoshFunctionTests.cs
+++ b/EXL.Tests/Functions/Mathematical/AcoshFunctionTests.cs
@@ -1,4 +1,4 @@
-﻿using EXL.Functions.Mathematical;
+using EXL.Functions.Mathematical;
 
 namespace EXL.Tests.Functions.Mathematical
 {
@@ -6,6 +6,7 @@ namespace EXL.Tests.Functions.Mathematical
     public class AcoshFunctionTests
     {
         private AcoshFunction _acoshFunction;
+        private static readonly object[] args = new object[] { };
 
         [SetUp]
         public void SetUp()
@@ -41,7 +42,7 @@ namespace EXL.Tests.Functions.Mathematical
         [Test]
         public void Execute_WithEmptyArguments_ThrowsInvalidOperationException()
         {
-            Assert.Throws<InvalidOperationException>(() => _acoshFunction.Execute(new object[] { }));
+            Assert.Throws<InvalidOperationException>(() => _acoshFunction.Execute(args));
         }
     }
 }

--- a/EXL.Tests/Utils/ChecksTests.cs
+++ b/EXL.Tests/Utils/ChecksTests.cs
@@ -6,34 +6,6 @@ namespace EXL.Tests.Utils
     public class ChecksTests
     {
         [Test]
-        public void CanConvertToDouble_WithValidDoubleString_ReturnsTrue()
-        {
-            double result = 0;
-            Assert.DoesNotThrow(() => Checks.CanConvertToDouble("123.45", "Exception Message", out result));
-            Assert.That(result, Is.EqualTo(123.45));
-        }
-
-        [Test]
-        public void CanConvertToDouble_WithValidIntString_ReturnsTrue()
-        {
-            double result = 0;
-            Assert.DoesNotThrow(() => Checks.CanConvertToDouble("123", "Exception Message", out result));
-            Assert.That(result, Is.EqualTo(123));
-        }
-
-        [Test]
-        public void CanConvertToDouble_WithInvalidString_ThrowsInvalidCastException()
-        {
-            Assert.Throws<InvalidCastException>(() => Checks.CanConvertToDouble("invalid", "Exception Message", out var result));
-        }
-
-        [Test]
-        public void CanConvertToDouble_WithNonNumericObject_ThrowsInvalidCastException()
-        {
-            Assert.Throws<InvalidCastException>(() => Checks.CanConvertToDouble(new object(), "Exception Message", out var result));
-        }
-
-        [Test]
         public void TryConvertToDouble_WithValidDoubleString_ReturnsTrue()
         {
             var success = Checks.TryConvertToDouble("123.45", out var result);
@@ -85,6 +57,49 @@ namespace EXL.Tests.Utils
             {
                 Assert.That(success, Is.False);
                 Assert.That(result, Is.EqualTo(0));
+            });
+        }
+        [Test]
+        public void TryConvertToDouble_WithCommaDecimalSeparator_ReturnsTrue()
+        {
+            var success = Checks.TryConvertToDouble("123,45", out var result);
+            Assert.Multiple(() =>
+            {
+                Assert.That(success, Is.True);
+                Assert.That(result, Is.EqualTo(123.45));
+            });
+        }
+
+        [Test]
+        public void TryConvertToDouble_WithPeriodDecimalSeparator_ReturnsTrue()
+        {
+            var success = Checks.TryConvertToDouble("123.45", out var result);
+            Assert.Multiple(() =>
+            {
+                Assert.That(success, Is.True);
+                Assert.That(result, Is.EqualTo(123.45));
+            });
+        }
+
+        [Test]
+        public void TryConvertToDouble_WithTrailingSpaces_ReturnsTrue()
+        {
+            var success = Checks.TryConvertToDouble(" 123.45 ", out var result);
+            Assert.Multiple(() =>
+            {
+                Assert.That(success, Is.True);
+                Assert.That(result, Is.EqualTo(123.45));
+            });
+        }
+
+        [Test]
+        public void TryConvertToDouble_WithNegativeNumber_ReturnsTrue()
+        {
+            var success = Checks.TryConvertToDouble("-123.45", out var result);
+            Assert.Multiple(() =>
+            {
+                Assert.That(success, Is.True);
+                Assert.That(result, Is.EqualTo(-123.45));
             });
         }
     }

--- a/EXL/Functions/Array/MaxFunction.cs
+++ b/EXL/Functions/Array/MaxFunction.cs
@@ -1,22 +1,19 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace EXL.Functions.Array
+﻿namespace EXL.Functions.Array
 {
     public class MaxFunction : IFunction
     {
         public object Execute(object[] args)
         {
-            if (args.Length != 1 || !(args[0] is double[]))
+            if (args.Length != 1 || args[0] is not double[])
             {
                 throw new InvalidOperationException("The MAX function requires a single array as input.");
             }
 
             var array = ((double[])args[0]).OfType<double>().ToArray();
-            if (array.Length == 0) throw new InvalidOperationException("double[] cannot be empty.");
+            if (array.Length == 0)
+            {
+                throw new InvalidOperationException("double[] cannot be empty.");
+            }
 
             return array.Max();
         }

--- a/EXL/Functions/FunctionFactory.cs
+++ b/EXL/Functions/FunctionFactory.cs
@@ -9,37 +9,37 @@ namespace EXL.Functions
 
         public FunctionFactory()
         {
-            _functions["ABS"] = new AbsFunction();
-            _functions["ACOS"] = new AcosFunction();
-            _functions["ACOSH"] = new AcoshFunction();
-            _functions["ASIN"] = new AsinFunction();
-            _functions["ASINH"] = new AsinhFunction();
-            _functions["CEILING"] = new CeilingFunction();
-            _functions["COMBINATION"] = new CombinationFunction();
-            _functions["COS"] = new CosFunction();
-            _functions["DEGREES"] = new DegreesFunction();
-            _functions["EVEN"] = new EvenFunction();
-            _functions["EXP"] = new ExpFunction();
-            _functions["FLOOR"] = new FloorFunction();
-            _functions["LOG"] = new LogFunction();
-            _functions["MOD"] = new ModFunction();
-            _functions["ODD"] = new OddFunction();
-            _functions["POWER"] = new PowerFunction();
-            _functions["QUOTIENT"] = new QuotientFunction();
-            _functions["RAND"] = new RandFunction();
-            _functions["SIN"] = new SinFunction();
+            this._functions["ABS"] = new AbsFunction();
+            this._functions["ACOS"] = new AcosFunction();
+            this._functions["ACOSH"] = new AcoshFunction();
+            this._functions["ASIN"] = new AsinFunction();
+            this._functions["ASINH"] = new AsinhFunction();
+            this._functions["CEILING"] = new CeilingFunction();
+            this._functions["COMBINATION"] = new CombinationFunction();
+            this._functions["COS"] = new CosFunction();
+            this._functions["DEGREES"] = new DegreesFunction();
+            this._functions["EVEN"] = new EvenFunction();
+            this._functions["EXP"] = new ExpFunction();
+            this._functions["FLOOR"] = new FloorFunction();
+            this._functions["LOG"] = new LogFunction();
+            this._functions["MOD"] = new ModFunction();
+            this._functions["ODD"] = new OddFunction();
+            this._functions["POWER"] = new PowerFunction();
+            this._functions["QUOTIENT"] = new QuotientFunction();
+            this._functions["RAND"] = new RandFunction();
+            this._functions["SIN"] = new SinFunction();
 
-            _functions["AVERAGE"] = new AverageFunction();
-            _functions["COUNT"] = new CountFunction();
-            _functions["MAX"] = new MaxFunction();
+            this._functions["AVERAGE"] = new AverageFunction();
+            this._functions["COUNT"] = new CountFunction();
+            this._functions["MAX"] = new MaxFunction();
         }
 
         // Method to retrieve a function by name
         public IFunction GetFunction(string functionName)
         {
-            if (_functions.ContainsKey(functionName))
+            if (this._functions.ContainsKey(functionName))
             {
-                return _functions[functionName];
+                return this._functions[functionName];
             }
             throw new InvalidOperationException($"Unknown function: {functionName}");
         }
@@ -47,7 +47,7 @@ namespace EXL.Functions
         // Method to register additional functions
         public void RegisterFunction(string name, IFunction function)
         {
-            _functions[name] = function;
+            this._functions[name] = function;
         }
     }
 }

--- a/EXL/Functions/Mathematical/AcosFunction.cs
+++ b/EXL/Functions/Mathematical/AcosFunction.cs
@@ -1,9 +1,10 @@
-﻿using EXL.Utils;
+using EXL.Utils;
 
 namespace EXL.Functions.Mathematical
 {
     public class AcosFunction : IFunction
     {
+
         public object Execute(object[] args)
         {
             if (args.Length != 1)
@@ -11,9 +12,12 @@ namespace EXL.Functions.Mathematical
                 throw new InvalidOperationException("ACOS function requires exactly one argument: number.");
             }
 
-            Checks.CanConvertToDouble(args[0], "ACOS function requires a numeric value.", out double number);
+            if (!Checks.TryConvertToDouble(args[0], out var number))
+            {
+                throw new InvalidOperationException("ACOS function requires a numeric value.");
+            }
 
-            if (number < -1 || number > 1)
+            if (number < -1.0 || number > 1.0)
             {
                 throw new InvalidOperationException("The number argument for ACOS must be between -1 and 1.");
             }

--- a/EXL/Functions/Mathematical/AcoshFunction.cs
+++ b/EXL/Functions/Mathematical/AcoshFunction.cs
@@ -1,4 +1,4 @@
-﻿using EXL.Utils;
+using EXL.Utils;
 
 namespace EXL.Functions.Mathematical
 {
@@ -11,7 +11,10 @@ namespace EXL.Functions.Mathematical
                 throw new InvalidOperationException("ACOSH function requires exactly one argument: number.");
             }
 
-            Checks.CanConvertToDouble(args[0], "ACOSH function requires a numeric value.", out double number);
+            if (!Checks.TryConvertToDouble(args[0], out var number))
+            {
+                throw new InvalidOperationException("ACOS function requires a numeric value.");
+            }
 
             if (number < 1)
             {

--- a/EXL/Functions/Mathematical/AsinFunction.cs
+++ b/EXL/Functions/Mathematical/AsinFunction.cs
@@ -1,9 +1,21 @@
-﻿using EXL.Utils;
+using EXL.Utils;
 
 namespace EXL.Functions.Mathematical
 {
+    /// <summary>
+    /// Provides the implementation of the ASIN function which returns the arcsine of a number.
+    /// </summary>
     public class AsinFunction : IFunction
     {
+        /// <summary>
+        /// Executes the ASIN function on the provided argument.
+        /// </summary>
+        /// <param name="args">An array containing a single numeric value.</param>
+        /// <returns>The arcsine of the provided numeric value.</returns>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown when the number of arguments is not one, the argument is not a numeric value, 
+        /// or the numeric value is not between -1 and 1.
+        /// </exception>
         public object Execute(object[] args)
         {
             if (args.Length != 1)
@@ -11,7 +23,10 @@ namespace EXL.Functions.Mathematical
                 throw new InvalidOperationException("ASIN function requires exactly one argument: number.");
             }
 
-            Checks.CanConvertToDouble(args[0], "ASIN function requires a number argument", out double number);
+            if (!Checks.TryConvertToDouble(args[0], out double number))
+            {
+                throw new InvalidOperationException("ASIN function requires a number argument.");
+            }
 
             if (number < -1 || number > 1)
             {

--- a/EXL/Functions/Mathematical/AsinhFunction.cs
+++ b/EXL/Functions/Mathematical/AsinhFunction.cs
@@ -1,4 +1,4 @@
-﻿using EXL.Utils;
+using EXL.Utils;
 
 namespace EXL.Functions.Mathematical
 {
@@ -11,7 +11,10 @@ namespace EXL.Functions.Mathematical
                 throw new InvalidOperationException("ASINH function requires exactly one argument: number.");
             }
 
-            Checks.CanConvertToDouble(args[0], "ASINH function requires a number argument", out double number);
+            if (!Checks.TryConvertToDouble(args[0], out var number))
+            {
+                throw new InvalidOperationException("ACOS function requires a numeric value.");
+            }
 
             return Math.Asinh(number);  // Return the inverse hyperbolic sine of the number
         }

--- a/EXL/Functions/Mathematical/AtanFunction.cs
+++ b/EXL/Functions/Mathematical/AtanFunction.cs
@@ -1,4 +1,4 @@
-﻿using EXL.Utils;
+using EXL.Utils;
 
 namespace EXL.Functions.Mathematical
 {
@@ -8,15 +8,26 @@ namespace EXL.Functions.Mathematical
         {
             if (args.Length == 1)
             {
-                Checks.CanConvertToDouble(args[0], "ATAN function requires a numeric value.", out double number);
+                if (!Checks.TryConvertToDouble(args[0], out var number))
+                {
+                    throw new InvalidOperationException("ACOS function requires a numeric value.");
+                }
+
                 return Math.Atan(number);  // Return the arctangent in radians
             }
             else if (args.Length == 2)
             {
                 // Two arguments: Compute the arctangent based on (x, y) coordinates
-                Checks.CanConvertToDouble(args[0], "ATAN function requires a numeric value for the x-coordinate.", out double x);
-                Checks.CanConvertToDouble(args[1], "ATAN function requires a numeric value for the y-coordinate.", out double y);
-                
+                if (!Checks.TryConvertToDouble(args[0], out var x))
+                {
+                    throw new InvalidOperationException("ACOS function requires a numeric value.");
+                }
+
+                if (!Checks.TryConvertToDouble(args[1], out var y))
+                {
+                    throw new InvalidOperationException("ACOS function requires a numeric value.");
+                }
+
                 return Math.Atan2(x, y);  // Return the angle in radians
             }
             else

--- a/EXL/Functions/Mathematical/CeilingFunction.cs
+++ b/EXL/Functions/Mathematical/CeilingFunction.cs
@@ -1,4 +1,4 @@
-﻿using EXL.Utils;
+using EXL.Utils;
 
 namespace EXL.Functions.Mathematical
 {
@@ -11,8 +11,15 @@ namespace EXL.Functions.Mathematical
                 throw new InvalidOperationException("CEILING function requires exactly two arguments: number and significance.");
             }
 
-            Checks.CanConvertToDouble(args[0], "CEILING function requires a number argument.", out double number);
-            Checks.CanConvertToDouble(args[1], "CEILING function requires a significance argument.", out double significance);
+            if (!Checks.TryConvertToDouble(args[0], out var number))
+            {
+                throw new InvalidOperationException("ACOS function requires a numeric value.");
+            }
+
+            if (!Checks.TryConvertToDouble(args[1], out var significance))
+            {
+                throw new InvalidOperationException("ACOS function requires a numeric value.");
+            }
 
             if (significance == 0)
             {

--- a/EXL/Functions/Mathematical/CombinationFunction.cs
+++ b/EXL/Functions/Mathematical/CombinationFunction.cs
@@ -1,4 +1,4 @@
-﻿using EXL.Utils;
+using EXL.Utils;
 
 namespace EXL.Functions.Mathematical
 {
@@ -11,8 +11,15 @@ namespace EXL.Functions.Mathematical
                 throw new InvalidOperationException("COMBINATION function requires exactly two arguments: number and number_chosen.");
             }
 
-            Checks.CanConvertToDouble(args[0], "COMBINATION function requires a number argument for n.", out double x);
-            Checks.CanConvertToDouble(args[1], "COMBINATION function requires a number argument for k.", out double y);
+            if (!Checks.TryConvertToDouble(args[0], out var x))
+            {
+                throw new InvalidOperationException("ACOS function requires a numeric value.");
+            }
+
+            if (!Checks.TryConvertToDouble(args[1], out var y))
+            {
+                throw new InvalidOperationException("ACOS function requires a numeric value.");
+            }
 
             int n = (int)Math.Floor(x);  // Truncate to integer
             int k = (int)Math.Floor(y);  // Truncate to integer
@@ -22,7 +29,7 @@ namespace EXL.Functions.Mathematical
                 throw new InvalidOperationException("COMBINATION function requires number >= 0, number_chosen >= 0, and number >= number_chosen.");
             }
 
-            return Factorial(n) / (Factorial(k) * Factorial(n - k));
+            return this.Factorial(n) / (this.Factorial(k) * this.Factorial(n - k));
         }
 
         private double Factorial(int number)

--- a/EXL/Functions/Mathematical/CosFunction.cs
+++ b/EXL/Functions/Mathematical/CosFunction.cs
@@ -1,4 +1,4 @@
-﻿using EXL.Utils;
+using EXL.Utils;
 
 namespace EXL.Functions.Mathematical
 {
@@ -11,7 +11,10 @@ namespace EXL.Functions.Mathematical
                 throw new InvalidOperationException("COS function requires exactly one argument: number.");
             }
 
-            Checks.CanConvertToDouble(args[0], "COS function requires a number argument", out double number);
+            if (!Checks.TryConvertToDouble(args[0], out var number))
+            {
+                throw new InvalidOperationException("ACOS function requires a numeric value.");
+            }
 
             return Math.Cos(number);  // Return the cosine of the angle (in radians)
         }

--- a/EXL/Functions/Mathematical/DegreesFunction.cs
+++ b/EXL/Functions/Mathematical/DegreesFunction.cs
@@ -1,4 +1,4 @@
-﻿using EXL.Utils;
+using EXL.Utils;
 
 namespace EXL.Functions.Mathematical
 {
@@ -11,7 +11,10 @@ namespace EXL.Functions.Mathematical
                 throw new InvalidOperationException("DEGREES function requires exactly one argument: angle in radians.");
             }
 
-            Checks.CanConvertToDouble(args[0], "DEGREES function requires a numeric value.", out double radians);
+            if (!Checks.TryConvertToDouble(args[0], out var radians))
+            {
+                throw new InvalidOperationException("ACOS function requires a numeric value.");
+            }
 
             return radians * (180.0 / Math.PI);  // Convert radians to degrees
         }

--- a/EXL/Functions/Mathematical/EvenFunction.cs
+++ b/EXL/Functions/Mathematical/EvenFunction.cs
@@ -1,4 +1,4 @@
-﻿using EXL.Utils;
+using EXL.Utils;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -16,7 +16,10 @@ namespace EXL.Functions.Mathematical
                 throw new InvalidOperationException("EVEN function requires exactly one argument: number.");
             }
 
-           Checks.CanConvertToDouble(args[0], "EVEN function requires a number argument", out double number);
+            if (!Checks.TryConvertToDouble(args[0], out var number))
+            {
+                throw new InvalidOperationException("ACOS function requires a numeric value.");
+            }
 
             // Check if the input is nonnumeric
             if (double.IsNaN(number))

--- a/EXL/Functions/Mathematical/ExpFunction.cs
+++ b/EXL/Functions/Mathematical/ExpFunction.cs
@@ -1,4 +1,4 @@
-﻿using EXL.Utils;
+using EXL.Utils;
 
 namespace EXL.Functions.Mathematical
 {
@@ -11,7 +11,10 @@ namespace EXL.Functions.Mathematical
                 throw new InvalidOperationException("EXP function requires exactly one argument: number.");
             }
 
-            Checks.CanConvertToDouble(args[0], "EXP function requires a number argument", out double number);
+            if (!Checks.TryConvertToDouble(args[0], out var number))
+            {
+                throw new InvalidOperationException("ACOS function requires a numeric value.");
+            }
 
             return Math.Exp(number);  // Return e raised to the power of number
         }

--- a/EXL/Functions/Mathematical/LogFunction.cs
+++ b/EXL/Functions/Mathematical/LogFunction.cs
@@ -1,4 +1,4 @@
-﻿using EXL.Utils;
+using EXL.Utils;
 
 namespace EXL.Functions.Mathematical
 {
@@ -11,7 +11,10 @@ namespace EXL.Functions.Mathematical
                 throw new InvalidOperationException("LOG function requires one or two arguments: number and an optional base.");
             }
 
-          Checks.CanConvertToDouble(args[0], "LOG function requires a number argument.", out double number);
+            if (!Checks.TryConvertToDouble(args[0], out var number))
+            {
+                throw new InvalidOperationException("ACOS function requires a numeric value.");
+            }
 
             if (number <= 0)
             {
@@ -20,7 +23,10 @@ namespace EXL.Functions.Mathematical
 
             if (args.Length == 2)
             {
-                Checks.CanConvertToDouble(args[1], "LOG function requires a base argument.", out double logBase);
+                if (!Checks.TryConvertToDouble(args[1], out var logBase))
+                {
+                    throw new InvalidOperationException("ACOS function requires a numeric value.");
+                }
                 return Math.Log(number, logBase);  // Return the logarithm of the number with the specified base
             }
             else

--- a/EXL/Functions/Mathematical/ModFunction.cs
+++ b/EXL/Functions/Mathematical/ModFunction.cs
@@ -1,4 +1,4 @@
-﻿using EXL.Utils;
+using EXL.Utils;
 
 namespace EXL.Functions.Mathematical
 {
@@ -11,8 +11,15 @@ namespace EXL.Functions.Mathematical
                 throw new InvalidOperationException("MOD function requires exactly two arguments: number and divisor.");
             }
 
-            Checks.CanConvertToDouble(args[0], "MOD function requires a number argument", out double number);
-            Checks.CanConvertToDouble(args[1], "MOD function requires a divisor argument", out double divisor);
+            if (!Checks.TryConvertToDouble(args[0], out var number))
+            {
+                throw new InvalidOperationException("ACOS function requires a numeric value.");
+            }
+
+            if (!Checks.TryConvertToDouble(args[0], out var divisor))
+            {
+                throw new InvalidOperationException("ACOS function requires a numeric value.");
+            }
 
             if (divisor == 0)
             {

--- a/EXL/Functions/Mathematical/OddFunction.cs
+++ b/EXL/Functions/Mathematical/OddFunction.cs
@@ -1,4 +1,4 @@
-﻿using EXL.Utils;
+using EXL.Utils;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -16,7 +16,10 @@ namespace EXL.Functions.Mathematical
                 throw new InvalidOperationException("ODD function requires exactly one argument: number.");
             }
 
-            Checks.CanConvertToDouble(args[0], "ODD function requires a number argument", out double number);
+            if (!Checks.TryConvertToDouble(args[0], out var number))
+            {
+                throw new InvalidOperationException("ACOS function requires a numeric value.");
+            }
 
             // Check if the input is nonnumeric
             if (double.IsNaN(number))

--- a/EXL/Functions/Mathematical/PowerFunction.cs
+++ b/EXL/Functions/Mathematical/PowerFunction.cs
@@ -1,4 +1,4 @@
-﻿using EXL.Utils;
+using EXL.Utils;
 
 namespace EXL.Functions.Mathematical
 {
@@ -11,8 +11,15 @@ namespace EXL.Functions.Mathematical
                 throw new InvalidOperationException("POWER function requires exactly two arguments: number and power.");
             }
 
-            Checks.CanConvertToDouble(args[0], "POWER function requires a number argument", out double number);
-            Checks.CanConvertToDouble(args[1], "POWER function requires a power argument", out double power);
+            if (!Checks.TryConvertToDouble(args[0], out var number))
+            {
+                throw new InvalidOperationException("ACOS function requires a numeric value.");
+            }
+
+            if (!Checks.TryConvertToDouble(args[0], out var power))
+            {
+                throw new InvalidOperationException("ACOS function requires a numeric value.");
+            }
 
             return Math.Pow(number, power);  // Return number raised to the power
         }

--- a/EXL/Functions/Mathematical/QuotientFunction.cs
+++ b/EXL/Functions/Mathematical/QuotientFunction.cs
@@ -1,4 +1,4 @@
-﻿using EXL.Utils;
+using EXL.Utils;
 
 namespace EXL.Functions.Mathematical
 {
@@ -11,8 +11,15 @@ namespace EXL.Functions.Mathematical
                 throw new InvalidOperationException("QUOTIENT function requires exactly two arguments: numerator and denominator.");
             }
 
-            Checks.CanConvertToDouble(args[0], "QUOTIENT function requires a numerator argument", out double numerator);
-            Checks.CanConvertToDouble(args[1], "QUOTIENT function requires a denominator argument", out double denominator);
+            if (!Checks.TryConvertToDouble(args[0], out var numerator))
+            {
+                throw new InvalidOperationException("ACOS function requires a numeric value.");
+            }
+
+            if (!Checks.TryConvertToDouble(args[0], out var denominator))
+            {
+                throw new InvalidOperationException("ACOS function requires a numeric value.");
+            }
 
             if (denominator == 0)
             {

--- a/EXL/Functions/Mathematical/RandFunction.cs
+++ b/EXL/Functions/Mathematical/RandFunction.cs
@@ -1,4 +1,4 @@
-﻿using EXL.Utils;
+using EXL.Utils;
 
 namespace EXL.Functions.Mathematical
 {
@@ -16,7 +16,10 @@ namespace EXL.Functions.Mathematical
             else if (args.Length == 1)
             {
                 // One argument: Return a random number between 1 and the argument
-                Checks.CanConvertToDouble(args[0], "RAND function requires a number argument", out double max);
+                if (!Checks.TryConvertToDouble(args[0], out var max))
+                {
+                    throw new InvalidOperationException("ACOS function requires a numeric value.");
+                }
 
                 if (max <= 1)
                 {
@@ -28,8 +31,15 @@ namespace EXL.Functions.Mathematical
             else if (args.Length == 2)
             {
                 // Two arguments: Return a random number between min and max
-                Checks.CanConvertToDouble(args[0], "RAND function requires a number argument", out double min);
-                Checks.CanConvertToDouble(args[1], "RAND function requires a number argument", out double max);
+                if (!Checks.TryConvertToDouble(args[0], out var min))
+                {
+                    throw new InvalidOperationException("ACOS function requires a numeric value.");
+                }
+
+                if (!Checks.TryConvertToDouble(args[1], out var max))
+                {
+                    throw new InvalidOperationException("ACOS function requires a numeric value.");
+                }
 
                 if (min >= max)
                 {

--- a/EXL/Functions/Mathematical/SinFunction.cs
+++ b/EXL/Functions/Mathematical/SinFunction.cs
@@ -1,4 +1,4 @@
-﻿using EXL.Utils;
+using EXL.Utils;
 
 namespace EXL.Functions.Mathematical
 {
@@ -11,7 +11,10 @@ namespace EXL.Functions.Mathematical
                 throw new InvalidOperationException("SIN function requires exactly one argument: number.");
             }
 
-            Checks.CanConvertToDouble(args[0], "SIN function requires a number argument", out double number);
+            if (!Checks.TryConvertToDouble(args[0], out var number))
+            {
+                throw new InvalidOperationException("ACOS function requires a numeric value.");
+            }
 
             return Math.Sin(number);  // Return the sine of the angle (in radians)
         }

--- a/EXL/Functions/Mathematical/TanFunction.cs
+++ b/EXL/Functions/Mathematical/TanFunction.cs
@@ -1,4 +1,4 @@
-﻿using EXL.Utils;
+using EXL.Utils;
 
 namespace EXL.Functions.Mathematical
 {
@@ -11,7 +11,10 @@ namespace EXL.Functions.Mathematical
                 throw new InvalidOperationException("TAN function requires exactly one argument: number.");
             }
 
-            Checks.CanConvertToDouble(args[0], "TAN function requires a number argument", out double number);
+            if (!Checks.TryConvertToDouble(args[0], out var number))
+            {
+                throw new InvalidOperationException("ACOS function requires a numeric value.");
+            }
 
             return Math.Tan(number);  // Return the tangent of the angle (in radians)
         }

--- a/EXL/Parser.cs
+++ b/EXL/Parser.cs
@@ -12,44 +12,44 @@ namespace EXL
 
         public Parser(Tokenizer tokenizer, Dictionary<string, object> context)
         {
-            _tokenizer = tokenizer;
-            _context = context;
-            _currentToken = _tokenizer.GetNextToken();
-            _functionFactory = new FunctionFactory();
+            this._tokenizer = tokenizer;
+            this._context = context;
+            this._currentToken = this._tokenizer.GetNextToken();
+            this._functionFactory = new FunctionFactory();
         }
 
         private void Eat(TokenType tokenType)
         {
-            if (_currentToken.Type == tokenType)
+            if (this._currentToken.Type == tokenType)
             {
-                _currentToken = _tokenizer.GetNextToken();
+                this._currentToken = this._tokenizer.GetNextToken();
             }
             else
             {
-                throw new InvalidOperationException($"Unexpected token: {_currentToken.Type}");
+                throw new InvalidOperationException($"Unexpected token: {this._currentToken.Type}");
             }
         }
 
         // Parse expressions involving addition and subtraction (lower precedence)
         public object ParseExpression()
         {
-            var result = ParseTerm();
+            var result = this.ParseTerm();
 
-            while (_currentToken.Type == TokenType.ADDITION || _currentToken.Type == TokenType.SUBTRACTION)
+            while (this._currentToken.Type == TokenType.ADDITION || this._currentToken.Type == TokenType.SUBTRACTION)
             {
-                if (_currentToken.Type == TokenType.ADDITION)
+                if (this._currentToken.Type == TokenType.ADDITION)
                 {
-                    Eat(TokenType.ADDITION);
-                    var right = ParseTerm();
+                    this.Eat(TokenType.ADDITION);
+                    var right = this.ParseTerm();
 
                     // Handle array concatenation only for the '+' operator
                     if (result is double[] && right is double[])
                     {
-                        result = CombineArrays((double[])result, (double[])right);
+                        result = this.CombineArrays((double[])result, (double[])right);
                     }
                     else if (result is string[] && right is string[])
                     {
-                        result = CombineArrays((string[])result, (string[])right);
+                        result = this.CombineArrays((string[])result, (string[])right);
                     }
                     else if (result is string || right is string)
                     {
@@ -60,10 +60,10 @@ namespace EXL
                         result = Convert.ToDouble(result) + Convert.ToDouble(right);  // Perform addition
                     }
                 }
-                else if (_currentToken.Type == TokenType.SUBTRACTION)
+                else if (this._currentToken.Type == TokenType.SUBTRACTION)
                 {
-                    Eat(TokenType.SUBTRACTION);
-                    var right = ParseTerm();
+                    this.Eat(TokenType.SUBTRACTION);
+                    var right = this.ParseTerm();
 
                     // Disallow subtraction for arrays, but allow for numbers and strings
                     if (result is double[] || right is double[])
@@ -88,20 +88,20 @@ namespace EXL
         // Parse terms involving multiplication and division (higher precedence)
         private object ParseTerm()
         {
-            var result = ParseFactor();
+            var result = this.ParseFactor();
 
-            while (_currentToken.Type == TokenType.MULTIPLICATION || _currentToken.Type == TokenType.DIVISION)
+            while (this._currentToken.Type == TokenType.MULTIPLICATION || this._currentToken.Type == TokenType.DIVISION)
             {
-                if (_currentToken.Type == TokenType.MULTIPLICATION)
+                if (this._currentToken.Type == TokenType.MULTIPLICATION)
                 {
-                    Eat(TokenType.MULTIPLICATION);
-                    var right = ParseFactor();
+                    this.Eat(TokenType.MULTIPLICATION);
+                    var right = this.ParseFactor();
                     result = Convert.ToDouble(result) * Convert.ToDouble(right);  // Perform multiplication
                 }
-                else if (_currentToken.Type == TokenType.DIVISION)
+                else if (this._currentToken.Type == TokenType.DIVISION)
                 {
-                    Eat(TokenType.DIVISION);
-                    var right = ParseFactor();
+                    this.Eat(TokenType.DIVISION);
+                    var right = this.ParseFactor();
 
                     if (Convert.ToDouble(right) == 0)
                     {
@@ -118,49 +118,49 @@ namespace EXL
         // Parse factors: numbers, variables, and expressions inside parentheses
         private object ParseFactor()
         {
-            if (_currentToken.Type == TokenType.LEFT_PAREN)
+            if (this._currentToken.Type == TokenType.LEFT_PAREN)
             {
                 // Handle parentheses
-                Eat(TokenType.LEFT_PAREN);
-                var result = ParseExpression();  // Parse the expression inside the parentheses
-                Eat(TokenType.RIGHT_PAREN);  // Match the closing parenthesis
+                this.Eat(TokenType.LEFT_PAREN);
+                var result = this.ParseExpression();  // Parse the expression inside the parentheses
+                this.Eat(TokenType.RIGHT_PAREN);  // Match the closing parenthesis
                 return result;
             }
 
-            if (_currentToken.Type == TokenType.LEFT_BRACKET)
+            if (this._currentToken.Type == TokenType.LEFT_BRACKET)
             {
                 // Handle arrays
-                return ParseArray();
+                return this.ParseArray();
             }
 
-            var token = _currentToken;
+            var token = this._currentToken;
 
             if (token.Type == TokenType.NUMBER)
             {
-                Eat(TokenType.NUMBER);
+                this.Eat(TokenType.NUMBER);
                 return token.Value.Contains(".") ? double.Parse(token.Value) : int.Parse(token.Value);
             }
 
             if (token.Type == TokenType.STRING)
             {
-                Eat(TokenType.STRING);
+                this.Eat(TokenType.STRING);
                 return token.Value;  // Return string as-is
             }
 
             if (token.Type == TokenType.BOOL)
             {
-                Eat(TokenType.BOOL);
+                this.Eat(TokenType.BOOL);
                 return token.Value == "TRUE";  // Return true or false
             }
 
             if (token.Type == TokenType.VARIABLE)
             {
                 var variableName = token.Value;
-                Eat(TokenType.VARIABLE);
+                this.Eat(TokenType.VARIABLE);
 
-                if (_context.ContainsKey(variableName))
+                if (this._context.ContainsKey(variableName))
                 {
-                    return _context[variableName];
+                    return this._context[variableName];
                 }
                 else
                 {
@@ -168,9 +168,9 @@ namespace EXL
                 }
             }
 
-            if (_currentToken.Type == TokenType.FUNCTION)
+            if (this._currentToken.Type == TokenType.FUNCTION)
             {
-                return ParseFunction();
+                return this.ParseFunction();
             }
 
             throw new InvalidOperationException($"Unexpected token: {token.Type}");
@@ -178,20 +178,20 @@ namespace EXL
 
         private object ParseArray()
         {
-            Eat(TokenType.LEFT_BRACKET);  // Consume the opening bracket '['
+            this.Eat(TokenType.LEFT_BRACKET);  // Consume the opening bracket '['
 
             var elements = new List<object>();
             var arrayType = TokenType.NUMBER_ARRAY;  // Default to number array
 
-            while (_currentToken.Type != TokenType.RIGHT_BRACKET)
+            while (this._currentToken.Type != TokenType.RIGHT_BRACKET)
             {
-                if (_currentToken.Type == TokenType.COMMA)
+                if (this._currentToken.Type == TokenType.COMMA)
                 {
-                    Eat(TokenType.COMMA);  // Consume commas between array elements
+                    this.Eat(TokenType.COMMA);  // Consume commas between array elements
                 }
                 else
                 {
-                    var element = ParseFactor();  // Parse each element inside the array
+                    var element = this.ParseFactor();  // Parse each element inside the array
                     elements.Add(element);
 
                     // Determine the array type dynamically
@@ -206,7 +206,7 @@ namespace EXL
                 }
             }
 
-            Eat(TokenType.RIGHT_BRACKET);  // Consume the closing bracket ']'
+            this.Eat(TokenType.RIGHT_BRACKET);  // Consume the closing bracket ']'
 
             // Convert the elements to an appropriate array based on type
             return arrayType switch
@@ -220,27 +220,27 @@ namespace EXL
 
         private object ParseFunction()
         {
-            var functionName = _currentToken.Value;
-            Eat(TokenType.FUNCTION);
+            var functionName = this._currentToken.Value;
+            this.Eat(TokenType.FUNCTION);
 
-            Eat(TokenType.LEFT_PAREN);  // Expect '('
+            this.Eat(TokenType.LEFT_PAREN);  // Expect '('
 
             // Parse arguments inside the function call
             var args = new List<object>();
-            while (_currentToken.Type != TokenType.RIGHT_PAREN)
+            while (this._currentToken.Type != TokenType.RIGHT_PAREN)
             {
-                args.Add(ParseExpression());
+                args.Add(this.ParseExpression());
 
-                if (_currentToken.Type == TokenType.COMMA)
+                if (this._currentToken.Type == TokenType.COMMA)
                 {
-                    Eat(TokenType.COMMA);  // Consume comma between arguments
+                    this.Eat(TokenType.COMMA);  // Consume comma between arguments
                 }
             }
 
-            Eat(TokenType.RIGHT_PAREN);  // Expect ')'
+            this.Eat(TokenType.RIGHT_PAREN);  // Expect ')'
 
             // Retrieve and execute the function using the factory
-            var function = _functionFactory.GetFunction(functionName);
+            var function = this._functionFactory.GetFunction(functionName);
             return function.Execute(args.ToArray());
         }
 

--- a/EXL/Token.cs
+++ b/EXL/Token.cs
@@ -29,8 +29,8 @@
 
         public Token(TokenType type, string value)
         {
-            Type = type;
-            Value = value;
+            this.Type = type;
+            this.Value = value;
         }
     }
 

--- a/EXL/Tokenizer.cs
+++ b/EXL/Tokenizer.cs
@@ -13,96 +13,96 @@ namespace EXL
 
         public Tokenizer(string input)
         {
-            _input = input;
-            _position = 0;
+            this._input = input;
+            this._position = 0;
         }
 
-        private char CurrentChar => _position < _input.Length ? _input[_position] : '\0';
+        private char CurrentChar => this._position < this._input.Length ? this._input[this._position] : '\0';
 
         public Token GetNextToken()
         {
-            while (CurrentChar != '\0')
+            while (this.CurrentChar != '\0')
             {
-                if (char.IsWhiteSpace(CurrentChar))
+                if (char.IsWhiteSpace(this.CurrentChar))
                 {
-                    _position++;
+                    this._position++;
                     continue;
                 }
 
                 // Handle strings enclosed in quotes
-                if (CurrentChar == '"' || CurrentChar == '\'')
+                if (this.CurrentChar == '"' || this.CurrentChar == '\'')
                 {
-                    return GetString();
+                    return this.GetString();
                 }
 
                 // Handle numbers
-                if (char.IsDigit(CurrentChar) || CurrentChar == '.')
+                if (char.IsDigit(this.CurrentChar) || this.CurrentChar == '.')
                 {
-                    return GetNumber();
+                    return this.GetNumber();
                 }
 
                 // Handle operators
-                if (CurrentChar == '+')
+                if (this.CurrentChar == '+')
                 {
-                    _position++;
+                    this._position++;
                     return new Token(TokenType.ADDITION, "+");
                 }
 
-                if (CurrentChar == '-')
+                if (this.CurrentChar == '-')
                 {
-                    _position++;
+                    this._position++;
                     return new Token(TokenType.SUBTRACTION, "-");
                 }
 
-                if (CurrentChar == '*')
+                if (this.CurrentChar == '*')
                 {
-                    _position++;
+                    this._position++;
                     return new Token(TokenType.MULTIPLICATION, "*");
                 }
 
-                if (CurrentChar == '/')
+                if (this.CurrentChar == '/')
                 {
-                    _position++;
+                    this._position++;
                     return new Token(TokenType.DIVISION, "/");
                 }
 
                 // Handle variables enclosed in curly braces
-                if (CurrentChar == '{')
+                if (this.CurrentChar == '{')
                 {
-                    return GetVariable();
+                    return this.GetVariable();
                 }
 
                 // Handle number arrays starting with [
-                if (CurrentChar == '[')
+                if (this.CurrentChar == '[')
                 {
-                    return GetArray();
+                    return this.GetArray();
                 }
 
-                if (CurrentChar == '(')
+                if (this.CurrentChar == '(')
                 {
-                    _position++;
+                    this._position++;
                     return new Token(TokenType.LEFT_PAREN, "(");
                 }
 
-                if (CurrentChar == ')')
+                if (this.CurrentChar == ')')
                 {
-                    _position++;
+                    this._position++;
                     return new Token(TokenType.RIGHT_PAREN, ")");
                 }
 
-                if (CurrentChar == ',')
+                if (this.CurrentChar == ',')
                 {
-                    _position++;
+                    this._position++;
                     return new Token(TokenType.COMMA, ",");
                 }
 
 
-                if (char.IsLetter(CurrentChar))
+                if (char.IsLetter(this.CurrentChar))
                 {
-                    return GetFunctionOrVariable();  // Handle functions or variables
+                    return this.GetFunctionOrVariable();  // Handle functions or variables
                 }
 
-                throw new InvalidOperationException($"Unexpected character: {CurrentChar}");
+                throw new InvalidOperationException($"Unexpected character: {this.CurrentChar}");
             }
 
             return new Token(TokenType.EOF, null);
@@ -110,19 +110,19 @@ namespace EXL
 
         private Token GetString()
         {
-            var stringDelimiter = CurrentChar;
-            _position++; // Skip the starting quote
+            var stringDelimiter = this.CurrentChar;
+            this._position++; // Skip the starting quote
 
             var sb = new StringBuilder();
-            while (CurrentChar != '\0' && CurrentChar != stringDelimiter)
+            while (this.CurrentChar != '\0' && this.CurrentChar != stringDelimiter)
             {
-                sb.Append(CurrentChar);
-                _position++;
+                sb.Append(this.CurrentChar);
+                this._position++;
             }
 
-            if (CurrentChar == stringDelimiter)
+            if (this.CurrentChar == stringDelimiter)
             {
-                _position++; // Skip the ending quote
+                this._position++; // Skip the ending quote
             }
             else
             {
@@ -137,11 +137,11 @@ namespace EXL
             var sb = new StringBuilder();
             bool haveDecimalPoint = false;
 
-            while (char.IsDigit(CurrentChar) || (!haveDecimalPoint && CurrentChar == '.'))
+            while (char.IsDigit(this.CurrentChar) || (!haveDecimalPoint && this.CurrentChar == '.'))
             {
-                sb.Append(CurrentChar);
-                haveDecimalPoint = CurrentChar == '.';
-                _position++;
+                sb.Append(this.CurrentChar);
+                haveDecimalPoint = this.CurrentChar == '.';
+                this._position++;
             }
 
             return new Token(TokenType.NUMBER, sb.ToString());
@@ -150,14 +150,14 @@ namespace EXL
         private Token GetFunctionOrVariable()
         {
             var sb = new StringBuilder();
-            while (char.IsLetter(CurrentChar))
+            while (char.IsLetter(this.CurrentChar))
             {
-                sb.Append(CurrentChar);
-                _position++;
+                sb.Append(this.CurrentChar);
+                this._position++;
             }
 
             // If followed by '(', it's a function
-            if (CurrentChar == '(')
+            if (this.CurrentChar == '(')
             {
                 return new Token(TokenType.FUNCTION, sb.ToString().ToUpperInvariant());  // Return function name as uppercase
             }
@@ -168,18 +168,18 @@ namespace EXL
 
         private Token GetVariable()
         {
-            _position++; // Skip the opening brace '{'
+            this._position++; // Skip the opening brace '{'
 
             var sb = new StringBuilder();
-            while (CurrentChar != '\0' && CurrentChar != '}')
+            while (this.CurrentChar != '\0' && this.CurrentChar != '}')
             {
-                sb.Append(CurrentChar);
-                _position++;
+                sb.Append(this.CurrentChar);
+                this._position++;
             }
 
-            if (CurrentChar == '}')
+            if (this.CurrentChar == '}')
             {
-                _position++; // Skip the closing brace '}'
+                this._position++; // Skip the closing brace '}'
             }
             else
             {
@@ -191,21 +191,21 @@ namespace EXL
 
         private bool IsStartOfBoolean()
         {
-            var remainingInput = _input.Substring(_position).ToLower();
+            var remainingInput = this._input.Substring(this._position).ToLower();
             return remainingInput.StartsWith("true") || remainingInput.StartsWith("false");
         }
 
         private Token GetBoolean()
         {
-            var remainingInput = _input.Substring(_position).ToLower();
+            var remainingInput = this._input.Substring(this._position).ToLower();
             if (remainingInput.StartsWith("true"))
             {
-                _position += 4; // Move past "true"
+                this._position += 4; // Move past "true"
                 return new Token(TokenType.BOOL, "TRUE");
             }
             else if (remainingInput.StartsWith("false"))
             {
-                _position += 5; // Move past "false"
+                this._position += 5; // Move past "false"
                 return new Token(TokenType.BOOL, "FALSE");
             }
 
@@ -215,10 +215,10 @@ namespace EXL
         private Token GetBooleanOrVariable()
         {
             var sb = new StringBuilder();
-            while (char.IsLetter(CurrentChar))
+            while (char.IsLetter(this.CurrentChar))
             {
-                sb.Append(CurrentChar);
-                _position++;
+                sb.Append(this.CurrentChar);
+                this._position++;
             }
 
             var word = sb.ToString().ToUpperInvariant();  // Convert to uppercase for case-insensitivity
@@ -234,34 +234,34 @@ namespace EXL
 
         private Token GetArray()
         {
-            _position++; // Skip the opening bracket '['
+            this._position++; // Skip the opening bracket '['
 
             var elements = new List<string>();
             var elementType = TokenType.NUMBER; // Default to number array initially
 
-            while (CurrentChar != '\0' && CurrentChar != ']')
+            while (this.CurrentChar != '\0' && this.CurrentChar != ']')
             {
                 // Skip commas and spaces
-                if (CurrentChar == ',' || char.IsWhiteSpace(CurrentChar))
+                if (this.CurrentChar == ',' || char.IsWhiteSpace(this.CurrentChar))
                 {
-                    _position++;
+                    this._position++;
                     continue;
                 }
 
                 // Check the type of the next element
-                if (char.IsDigit(CurrentChar) || CurrentChar == '.')
+                if (char.IsDigit(this.CurrentChar) || this.CurrentChar == '.')
                 {
-                    elements.Add(GetNumber().Value);
+                    elements.Add(this.GetNumber().Value);
                     elementType = TokenType.NUMBER_ARRAY;
                 }
-                else if (CurrentChar == '"' || CurrentChar == '\'')
+                else if (this.CurrentChar == '"' || this.CurrentChar == '\'')
                 {
-                    elements.Add(GetString().Value);
+                    elements.Add(this.GetString().Value);
                     elementType = TokenType.STRING_ARRAY;
                 }
-                else if (char.IsLetter(CurrentChar))
+                else if (char.IsLetter(this.CurrentChar))
                 {
-                    var boolToken = GetBooleanOrVariable();
+                    var boolToken = this.GetBooleanOrVariable();
                     if (boolToken.Type == TokenType.BOOL)
                     {
                         elements.Add(boolToken.Value);
@@ -278,9 +278,9 @@ namespace EXL
                 }
             }
 
-            if (CurrentChar == ']')
+            if (this.CurrentChar == ']')
             {
-                _position++; // Skip the closing bracket ']'
+                this._position++; // Skip the closing bracket ']'
             }
             else
             {

--- a/EXL/Utils/Checks.cs
+++ b/EXL/Utils/Checks.cs
@@ -8,27 +8,6 @@ namespace EXL.Utils
     public static class Checks
     {
         /// <summary>
-        /// Attempts to convert the specified value to a double.
-        /// </summary>
-        /// <param name="value">The value to be converted to a double.</param>
-        /// <param name="pattern">The string pattern to use in the exception message.</param>
-        /// <param name="result">When this method returns, contains the double value equivalent to the value contained in <paramref name="value"/>, if the conversion succeeded, or zero if the conversion failed. This parameter is passed uninitialized.</param>
-        /// <exception cref="InvalidCastException">Thrown when the provided value cannot be converted to a double.</exception>
-        /// <remarks>
-        /// This method uses <see cref="double.TryParse(string, NumberStyles, IFormatProvider, out double)"/> to attempt the conversion. If the conversion fails, an <see cref="InvalidCastException"/> is thrown.
-        /// </remarks>
-        public static void CanConvertToDouble(object value, string pattern, out double result)
-        {
-            var styles = NumberStyles.Float | NumberStyles.AllowThousands;
-            var culture = CultureInfo.InvariantCulture;
-
-            if (!double.TryParse(value.ToString(), styles, culture, out result))
-            {
-                throw new InvalidCastException(pattern);
-            }
-        }
-
-        /// <summary>
         /// Tries to convert the specified value to a double.
         /// </summary>
         /// <param name="value">The value to be converted to a double.</param>
@@ -45,7 +24,24 @@ namespace EXL.Utils
                 return false;
             }
 
-            return double.TryParse(value.ToString(), NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out result);
+            return double.TryParse(NormalizeDecimal(value.ToString()), out result);
+        }
+
+        /// <summary>
+        /// Normalizes the decimal separator in the specified string value.
+        /// </summary>
+        /// <param name="value">The string value to normalize.</param>
+        /// <returns>A string with the normalized decimal separator.</returns>
+        private static string NormalizeDecimal(string? value)
+        {
+            if (value == null)
+            {
+                return string.Empty;
+            }
+
+            return NumberFormatInfo.CurrentInfo.NumberDecimalSeparator == "."
+                ? value.Replace(",", ".")
+                : value.Replace(".", ",");
         }
     }
 }

--- a/Worker/Worker.csproj
+++ b/Worker/Worker.csproj
@@ -8,13 +8,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\EXL\EXL.csproj" />
   </ItemGroup>
 

--- a/docs/functions/math_and_trig/ABS.md
+++ b/docs/functions/math_and_trig/ABS.md
@@ -1,0 +1,37 @@
+# **`ABS` Function**
+
+### Description
+Returns the absolute value of a number or an array of numbers. The absolute value of a number is the number without the sign.
+
+### Syntax
+
+You can use the `ABS` function to calculate the absolute value of a number.
+```
+ABS(number)
+```
+|Argument|Description|
+|:--|:--|
+|number|Required. The real number of which you want the absolute value.|
+
+Alternatively, you can use the `ABS` function to calculate the absolute values of an array of numbers.
+
+```
+ABS([numbers])
+```
+|Argument|Description|
+|:--|:--|
+|numbers|Required. An array of real numbers of which you want the absolute values of.|
+
+### Examples
+
+**Scenario 1**: *Using `ABS` to calculate the absolute value of a number*
+```
+ABS(-1)
+```
+**Output**
+```
+1
+```
+---
+
+


### PR DESCRIPTION
# What type of PR is this? (check all applicable)
- [ ] :sparkles: **Feature**: A new feature added to the project.
- [x] :bug: **Bugfix**: Fixes a bug in the project.
- [x] :recycle: **Refactor**: Code refactoring or improvements.
- [ ] :zap: **Performance**: Improves performance of the project.
- [x] :alembic: **Test**: Add, update, or pass tests.
- [ ] :art: **Style**: Code style or formatting changes (no functionality changes)
- [ ] :rotating_light: **Chore**: General maintenance (e.g., logs, dead code purging, etc.)
- [ ] :construction_worker: **CI**: Making changes in the CI/CD part of the project.
- [ ] :rewind: **Revert**: Revert something that went wrong.

## Description
This PR introduces a culture-aware approach for converting string representations of numbers to doubles by normalizing the decimal separator according to the current culture. The `TryConvertToDouble` method has been updated to handle locale-specific decimal separators through the newly added `NormalizeDecimal` helper function.

### Key Changes:
1. `TryConvertToDouble` Method Update:
    - The conversion logic has been enhanced to respect the decimal separator of the system's current culture using NormalizeDecimal.
    - This ensures that decimal numbers are accurately parsed across different locales, preventing conversion issues caused by mismatched separators (e.g., 0.5 being parsed as 5 or 0).

2. `NormalizeDecimal` Method:
    - A helper method that replaces the decimal separator in the string representation of a number, based on the current culture’s format.
    - If the culture uses a period (.) as a decimal separator, commas are replaced with periods. If it uses a comma, periods are replaced with commas.

### Example:
For cultures where the decimal separator is a **comma** (e.g., France):
- Input: `"1.25"`
- Conversion Result: `1,25` (comma as decimal separator)

For cultures where the decimal separator is a period (e.g., US):
- Input: `"1,25"`
- Conversion Result: `1.25` (period as decimal separator)

### Reasons for Change:
- **Global Usability**: The library can now be used globally, across any culture, without issues related to decimal representation.
- **Consistency**: Ensures that the conversion behavior remains consistent regardless of the user's locale.
- **Bug Fixes**: Fixes issues where decimal values were being misinterpreted based on the culture-specific decimal separator.

## Related Tickets & Documents

## Did you add tests?
- [x] :: Yes!
- [] :: No, and this is why: *please replace this line with details why tests have not been included*
- [] :: No, because I need help

## Added Documentation?
- [] :: README.md
- [x] :: Function Documentation
- [] :: No documentation is needed

## [Optional] Are there any post deployment tasks we need to perform?

## [Optional] What gif best describes this PR and how it makes you feel?
